### PR TITLE
Update store workflow to use client credentials

### DIFF
--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -11,6 +11,6 @@ jobs:
         with:
             extensionName: ${{ github.event.repository.name }}
         secrets:
-            accountUser: ${{ secrets.ACCOUNT_USER }}
-            accountPassword: ${{ secrets.ACCOUNT_PASSWORD }}
+            clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+            clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
             ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace deprecated `accountUser` / `accountPassword` secrets with the new `clientId` / `clientSecret` credentials
- `ACCOUNT_USER` -> `SHOPWARE_CLI_ACCOUNT_CLIENT_ID`
- `ACCOUNT_PASSWORD` -> `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET`

This aligns the workflow with the updated authentication method used by the Shopware store release action.